### PR TITLE
Fixed NAWS

### DIFF
--- a/telnetsrv/telnetsrvlib.py
+++ b/telnetsrv/telnetsrvlib.py
@@ -391,7 +391,7 @@ class TelnetHandlerBase(BaseRequestHandler):
     WILLACK = {
         ECHO: DONT,
         SGA: DO,
-        NAWS: DONT,
+        NAWS: DO,
         TTYPE: DO,
         LINEMODE: DONT,
         NEW_ENVIRON: DO,
@@ -502,6 +502,12 @@ class TelnetHandlerBase(BaseRequestHandler):
             cls(request, address, server)
         except socket.error:
             pass
+
+    def setnaws(self, naws):
+        ''' Set width and height of the terminal on initial connection'''
+        self.WIDTH = columns = (256 * ord(naws[0])) + ord(naws[1])
+        self.HEIGHT = (256 * ord(naws[2])) + ord(naws[3])
+        log.debug("Set width to %s and height to %s" % (self.WIDTH, self.HEIGHT))
 
     def setterm(self, term):
         "Set the curses structures for this terminal"

--- a/telnetsrv/telnetsrvlib.py
+++ b/telnetsrv/telnetsrvlib.py
@@ -807,17 +807,17 @@ class TelnetHandlerBase(BaseRequestHandler):
         self.write(chr(10)+text+chr(10))
         self.write(self._current_prompt+''.join(self._current_line))
 
-    def write(self, text):
+    def write(self, text, encoding='latin-1'):
         """Send a packet to the socket. This function cooks output."""
         text = str(text)    # eliminate any unicode or other snigglets
         text = text.replace(IAC, IAC+IAC)
         text = text.replace(chr(10), chr(13)+chr(10))
-        self.writecooked(text)
+        self.writecooked(text,encoding)
 
-    def writecooked(self, text):
+    def writecooked(self, text, encoding='latin-1'):
         """Put data directly into the output queue (bypass output cooker)"""
         if sys.version_info > (3, 0):
-            self.sock.sendall(text.encode('latin1'))
+            self.sock.sendall(text.encode(encoding))
         else:
             self.sock.sendall(text)
 


### PR DESCRIPTION
The README refers to client column width and row height being available, however the current master branch doesn't contain the code which sets this.

I reinstated code from @kjoconnor's [commit](https://github.com/Blindfreddy/telnetsrvlib3/commit/883a85abf3c02828f9573382f1594f4587d15dda) and fixed the parsing of the incoming size information using [code](https://github.com/jquast/x84/blob/cf3dff9be7280f424f6bcb0ea2fe13d16e7a5d97/x84/telnet.py#L737) from @jquast's x86 repo.

The other commit in this pull request is just an amend I found useful when trying to write utf-8 encoded strings to a client.